### PR TITLE
Fix for month display on bottom bar by making the months 0 based

### DIFF
--- a/src/stuff/constants.js
+++ b/src/stuff/constants.js
@@ -12,7 +12,6 @@ const MONTH = WEEK * 4
 const YEAR = MONTH * 12
 
 const MONTHMAP = [
-    "None",
     "Jan", "Feb", "Mar", "Apr",
     "May", "Jun","Jul", "Aug",
     "Sep", "Oct","Nov", "Dec"


### PR DESCRIPTION
I noticed Dec dates were turning out to be "None" and other months were off by one month. I saw that MONTHMAP[d.getMonth()] wasn't 0 based. Fixed it by removing "None" so that all the months were shifted left once.