### PR TITLE
Fixes crosshair not moving the cursor in FireFox

### DIFF
--- a/src/components/js/grid.js
+++ b/src/components/js/grid.js
@@ -103,24 +103,24 @@ export default class Grid {
         })
     }
 
-    mousemove(e) {
+    mousemove(event) {
         this.comp.$emit('cursor-changed', {
             grid_id: this.id, x: event.pageX, y: event.pageY
         })
         if (!this.drug) this.update()
     }
 
-    mouseout(e) {
+    mouseout(event) {
         this.comp.$emit('cursor-changed', {})
     }
 
-    mouseup(e) {
+    mouseup(event) {
         this.drug = null
     //    this.pinch = null
         this.comp.$emit('cursor-locked', false)
     }
 
-    mousedown(e) {
+    mousedown(event) {
         this.comp.$emit('cursor-locked', true)
     }
 


### PR DESCRIPTION
The cursor wasn't working in FireFox and throwing an error `ReferenceError: event is not defined`. Found that the parameter name wasn't matching up to the event variable in grid.js mouse event functions. The parameter is changed to match the variable name and also changed the other functions to match the new parameter name convention.

Quickly tested in latest Chrome and Firefox on Debian.