### PR TITLE
botbar: fix timezone conversion

### DIFF
--- a/src/components/js/botbar.js
+++ b/src/components/js/botbar.js
@@ -94,7 +94,7 @@ export default class Botbar {
 
     // TODO: implement time zones
     format_date(t) {
-        t += new Date().getTimezoneOffset() * MINUTE
+        t += new Date(t).getTimezoneOffset() * MINUTE
         let d = new Date(t)
 
         if (Utils.year_start(t) === t) return d.getFullYear()


### PR DESCRIPTION
- we need to get our local time offset to UTC at the time of
  the datapoint, not _current_ moment, as DST causes it to
  fluctuate over the year.