### PR TITLE
Implement candle zoom when ctrl key is pressed

### DIFF
--- a/src/components/js/grid.js
+++ b/src/components/js/grid.js
@@ -277,8 +277,14 @@ export default class Grid {
         if (delta < 0 && this.data.length <= this.MIN_ZOOM) return
         if (delta > 0 && this.data.length > this.MAX_ZOOM) return
 
-        let k = this.interval / 1000
-        this.range[0] -= delta * k * this.data.length
+        let k = this.interval / 1000, diff = delta * k * this.data.length
+        if (event.originalEvent.ctrlKey) {
+            let diff_x = event.originalEvent.offsetX / (this.canvas.width-1) * diff, diff_y = diff - diff_x;
+            this.range[0] -= diff_x
+            this.range[1] += diff_y
+        } else {
+            this.range[0] -= diff
+        }
 
         this.change_range()
 

--- a/src/components/js/grid.js
+++ b/src/components/js/grid.js
@@ -67,7 +67,7 @@ export default class Grid {
 
         mc.on('panmove', event => {
             if (this.drug) {
-                this.mousedrug(
+                this.mousedrag(
                     this.drug.x + event.deltaX,
                     this.drug.y + event.deltaY,
                 )
@@ -290,7 +290,7 @@ export default class Grid {
 
     }
 
-    mousedrug(x, y) {
+    mousedrag(x, y) {
 
         let dt = this.drug.t * (this.drug.x - x) / this.layout.width
 


### PR DESCRIPTION
TradingView allows zooming to a candle pointed by the mouse when ctrl key is held. This change enables this behavior